### PR TITLE
make theme selection work in all browsers

### DIFF
--- a/js/themes.mjs
+++ b/js/themes.mjs
@@ -9,13 +9,15 @@ export function init() {
         option.value = theme;
         option.innerText = theme;
 
-        option.addEventListener('click', setTheme)
-
         selectTheme.appendChild(option)
     }
+
+    selectTheme.addEventListener('change', setTheme)
 }
 
 async function setTheme(event) {
     const curr = document.getElementById('theme')
-    curr.href = `themes/${event.target.innerText.toLowerCase()}.css`
+    curr.href = `themes/${event.target.value.toLowerCase()}.css`
+
+    console.log(curr)
 }

--- a/js/themes.mjs
+++ b/js/themes.mjs
@@ -18,6 +18,4 @@ export function init() {
 async function setTheme(event) {
     const curr = document.getElementById('theme')
     curr.href = `themes/${event.target.value.toLowerCase()}.css`
-
-    console.log(curr)
 }


### PR DESCRIPTION
I was using an eventlistener on every option where I should be using an eventlistener on the select element itself that runs on change, which means chrome-based browsers can select themes too now